### PR TITLE
docs: removed pywin from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,6 @@ pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyvis==0.3.2
-pywin32==310
 PyYAML==6.0.2
 pyzmq==27.0.0
 referencing==0.36.2


### PR DESCRIPTION
Removed pywin32 from requirements.txt, since it causes issues when running in UNIX enviroments.